### PR TITLE
Update batch API version

### DIFF
--- a/charts/loghouse/templates/loghouse/loghouse-cronjob.yaml
+++ b/charts/loghouse/templates/loghouse/loghouse-cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v2alpha1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: {{ .Chart.Name }}-tables


### PR DESCRIPTION
Kubernetes 1.8.x switch to using v1beta1 for the batch API.